### PR TITLE
Delete backups older than N days.

### DIFF
--- a/lib/sheet.js
+++ b/lib/sheet.js
@@ -141,9 +141,12 @@ class BackupSheet extends Sheet {
   }
 
   /**
-   * @param {!Date} from_date Delete any entries strictly older than this date.
+   * @param {number} n_days Delete any entries strictly older than `n_days`.
    */
-  deleteBackupsOlderThan(from_date){
+  deleteBackupsOlderThanNDays(n_days){
+    const today = new Date().toISOString().slice(0, 10);
+    const from_date = today - n_days;
+
     let backup_column_id = this.getColumnId(BACKUP_DATE_FIELD_NAME);
     let num_rows = this._sheet.getLastRow() - 1;
     let date_range = this._sheet.getRange(2, backup_column_id, num_rows);
@@ -176,7 +179,6 @@ class BackupSheet extends Sheet {
       filtered_data.push(new_record);
     }
 
-    // TODO: delete any data older than HISTORY_DAYS
     // Write the data to the sheet along with today's date
     this.appendWithDate(filtered_data, this._BACKUP_DATE_FIELD_NAME, today);
   };

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ function main() {
     var sheet = new BackupSheet(sheet_name, FIELDS_TO_BACKUP[airtable_table_name]);
     var airtable_data = fetchDataFromAirtable(airtable_table_name, airtable_view_name);
     sheet.backupData(airtable_data);
+    sheet.deleteBackupsOlderThanNDays(60);
   }
 }
 


### PR DESCRIPTION
This changes the API of the BackupSheet class for deleting old backups:
We now specify a number of days instead of a specific date until which
to truncate old backups. This allows us to keep the code as simple as
possible in main.js, by removing the need to manipulate Date objects.